### PR TITLE
Add done message to create

### DIFF
--- a/book/src/2.getting-started/README.md
+++ b/book/src/2.getting-started/README.md
@@ -3,7 +3,7 @@
 First lets initialize an app.
 
 ```bash
-npx '@teams.sdk/cli' new hello-world
+npx '@teams.sdk/cli' new hello-world --start
 ```
 
 Here is what your terminal should look like:

--- a/packages/cli/src/commands/new/csharp.ts
+++ b/packages/cli/src/commands/new/csharp.ts
@@ -78,6 +78,9 @@ export function CSharp(): CommandModule<{}, Args> {
       await project.write();
 
       console.log(`✅ App "${name}" created successfully at ${projectDir}`);
+      // TODO: add ability to start the app automatically if `--start` is provided
+      console.log(`Next steps to start the app:`);
+      console.log(`cd ${name} && npm install && npm run dev`);
     },
   };
 }

--- a/packages/cli/src/commands/new/csharp.ts
+++ b/packages/cli/src/commands/new/csharp.ts
@@ -72,10 +72,12 @@ export function CSharp(): CommandModule<{}, Args> {
       const project = new Project(projectDir, name, 'csharp').addTemplate(template);
 
       if (ttk) {
-        project.addTeamsToolkit();
+        project.addTeamsToolkit('csharp');
       }
 
       await project.write();
+
+      console.log(`✅ App "${name}" created successfully at ${projectDir}`);
     },
   };
 }

--- a/packages/cli/src/commands/new/csharp.ts
+++ b/packages/cli/src/commands/new/csharp.ts
@@ -78,9 +78,6 @@ export function CSharp(): CommandModule<{}, Args> {
       await project.write();
 
       console.log(`✅ App "${name}" created successfully at ${projectDir}`);
-      // TODO: add ability to start the app automatically if `--start` is provided
-      console.log(`Next steps to start the app:`);
-      console.log(`cd ${name} && npm install && npm run dev`);
     },
   };
 }

--- a/packages/cli/src/commands/new/typescript.ts
+++ b/packages/cli/src/commands/new/typescript.ts
@@ -135,6 +135,9 @@ export function Typescript(_: Context): CommandModule<{}, z.infer<typeof ArgsSch
           stdio: 'inherit',
           shell: true,
         });
+      } else {
+        console.log(`Next steps to start the app:`);
+        console.log(`cd ${name} && npm install && npm run dev`);
       }
     },
   };

--- a/packages/cli/src/commands/new/typescript.ts
+++ b/packages/cli/src/commands/new/typescript.ts
@@ -1,13 +1,13 @@
+import cp from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
-import cp from 'node:child_process';
 
-import { z } from 'zod';
 import { CommandModule } from 'yargs';
+import { z } from 'zod';
 
-import { Project } from '../../project';
 import { Context } from '../../context';
+import { Project } from '../../project';
 
 const ArgsSchema = z.object({
   name: z.string(),
@@ -126,6 +126,8 @@ export function Typescript(_: Context): CommandModule<{}, z.infer<typeof ArgsSch
       }
 
       await project.write();
+
+      console.log(`✅ App "${name}" created successfully at ${projectDir}`);
 
       if (start) {
         console.log(`cd ${name} && npm install && npm run dev`);


### PR DESCRIPTION
After a new project is created, we don't see any messaging that something happened. 

![image](https://github.com/user-attachments/assets/9039424e-f739-4e72-93e6-2af7bf9d8060)


In this PR, we add some basic messaging to let the user know that the project was created successfully and if `--start` wasn't provided, it says how to get started.