### PR TITLE
Add passthrough arguments for model requests

### DIFF
--- a/packages/ai/src/models/chat.ts
+++ b/packages/ai/src/models/chat.ts
@@ -7,7 +7,7 @@ export type ChatParams<TExtraParams extends {}> = {
   readonly input: Message;
   readonly messages?: Memory;
   readonly functions?: Record<string, Function>;
-} & Partial<TExtraParams>;
+} & Partial<Omit<TExtraParams, 'model' | 'input' | 'messages' | 'functions'>>;
 
 export interface ChatModel<TExtraParams extends {} = {}> {
   chat(

--- a/packages/ai/src/models/chat.ts
+++ b/packages/ai/src/models/chat.ts
@@ -2,16 +2,16 @@ import { Function } from '../function';
 import { Memory } from '../memory';
 import { Message, ModelMessage, SystemMessage, UserMessage } from '../message';
 
-export interface ChatParams {
+export type ChatParams<TExtraParams extends {}> = {
   readonly system?: SystemMessage | UserMessage;
   readonly input: Message;
   readonly messages?: Memory;
   readonly functions?: Record<string, Function>;
-}
+} & Partial<TExtraParams>;
 
-export interface ChatModel {
+export interface ChatModel<TExtraParams extends {} = {}> {
   chat(
-    params: ChatParams,
+    params: ChatParams<TExtraParams>,
     onChunk?: (chunk: ModelMessage) => void | Promise<void>
   ): Promise<ModelMessage>;
 }

--- a/packages/ai/src/models/chat.ts
+++ b/packages/ai/src/models/chat.ts
@@ -7,7 +7,7 @@ export type ChatParams<TExtraParams extends {}> = {
   readonly input: Message;
   readonly messages?: Memory;
   readonly functions?: Record<string, Function>;
-} & Partial<Omit<TExtraParams, 'model' | 'input' | 'messages' | 'functions'>>;
+} & Partial<Omit<TExtraParams, 'system' | 'input' | 'messages' | 'functions'>>;
 
 export interface ChatModel<TExtraParams extends {} = {}> {
   chat(

--- a/packages/ai/src/models/chat.ts
+++ b/packages/ai/src/models/chat.ts
@@ -7,7 +7,7 @@ export type ChatParams<TExtraParams extends {}> = {
   readonly input: Message;
   readonly messages?: Memory;
   readonly functions?: Record<string, Function>;
-} & Partial<Omit<TExtraParams, 'system' | 'input' | 'messages' | 'functions'>>;
+} & Omit<TExtraParams, 'system' | 'input' | 'messages' | 'functions'>;
 
 export interface ChatModel<TExtraParams extends {} = {}> {
   chat(

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -12,7 +12,7 @@ export type ChatPromptOptions<TModelExtraParams extends {}> = {
   readonly instructions?: string | Template;
   readonly role?: 'system' | 'user';
   readonly messages?: Message[] | Memory;
-} & Partial<Omit<TModelExtraParams, 'model' | 'input' | 'messages' | 'functions'>>;
+} & Partial<Omit<TModelExtraParams, 'model' | 'instructions' | 'role' | 'messages'>>;
 
 export class ChatPrompt<TModelExtraParams extends {}> {
   readonly messages: Memory;

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -7,22 +7,22 @@ import { Schema } from '../schema';
 import { Template } from '../template';
 import { StringTemplate } from '../templates';
 
-export interface ChatPromptOptions {
-  readonly model: ChatModel;
+export type ChatPromptOptions<T extends {}> = T & {
+  readonly model: ChatModel<T>;
   readonly instructions?: string | Template;
   readonly role?: 'system' | 'user';
   readonly messages?: Message[] | Memory;
-}
+};
 
-export class ChatPrompt {
+export class ChatPrompt<TModelExtraParams extends {}> {
   readonly messages: Memory;
 
   protected readonly _role: 'system' | 'user';
-  protected readonly _model: ChatModel;
+  protected readonly _model: ChatModel<TModelExtraParams>;
   protected readonly _template: Template;
   protected readonly _functions: Record<string, Function> = {};
 
-  constructor(options: ChatPromptOptions) {
+  constructor(options: ChatPromptOptions<TModelExtraParams>) {
     this._role = options.role || 'system';
     this.messages =
       typeof options.messages === 'object' && !Array.isArray(options.messages)
@@ -63,9 +63,17 @@ export class ChatPrompt {
     return await fn.handler(args || {});
   }
 
-  async chat(input: string | ContentPart[], onChunk?: (chunk: string) => void | Promise<void>) {
-    if (typeof input === 'string') {
-      input = input.trim();
+  async chat(
+    inputArgs:
+      | string
+      | ContentPart[]
+      | { input: string | ContentPart[]; extraArgs?: TModelExtraParams },
+    onChunk?: (chunk: string) => void | Promise<void>
+  ) {
+    let input: string | ContentPart[] =
+      typeof inputArgs === 'object' && 'input' in inputArgs ? inputArgs.input : inputArgs;
+    if (typeof inputArgs === 'string') {
+      input = inputArgs.trim();
     }
 
     let buffer = '';
@@ -79,6 +87,9 @@ export class ChatPrompt {
       };
     }
 
+    const extraArgs =
+      typeof inputArgs === 'object' && 'extraArgs' in inputArgs ? inputArgs.extraArgs : undefined;
+
     const res = await this._model.chat(
       {
         input: {
@@ -88,6 +99,7 @@ export class ChatPrompt {
         system,
         messages: this.messages,
         functions: this._functions,
+        ...(extraArgs || ({} as TModelExtraParams)),
       },
       async (chunk) => {
         if (!chunk.content || !onChunk) return;

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -7,12 +7,12 @@ import { Schema } from '../schema';
 import { Template } from '../template';
 import { StringTemplate } from '../templates';
 
-export type ChatPromptOptions<TModelExtraParams extends {}> = TModelExtraParams & {
+export type ChatPromptOptions<TModelExtraParams extends {}> = {
   readonly model: ChatModel<TModelExtraParams>;
   readonly instructions?: string | Template;
   readonly role?: 'system' | 'user';
   readonly messages?: Message[] | Memory;
-};
+} & Partial<Omit<TModelExtraParams, 'model' | 'input' | 'messages' | 'functions'>>;
 
 export class ChatPrompt<TModelExtraParams extends {}> {
   readonly messages: Memory;

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -12,7 +12,13 @@ export type ChatPromptOptions<TModelExtraParams extends {}> = {
   readonly instructions?: string | Template;
   readonly role?: 'system' | 'user';
   readonly messages?: Message[] | Memory;
-} & Partial<Omit<TModelExtraParams, 'model' | 'instructions' | 'role' | 'messages'>>;
+} & Omit<TModelExtraParams, 'model' | 'instructions' | 'role' | 'messages'>;
+
+type CheckIfContainsNonOptional<T> = {} extends {
+  [K in keyof T]: T[K] extends Required<T>[K] ? never : K;
+}
+  ? never
+  : T;
 
 export class ChatPrompt<TModelExtraParams extends {}> {
   readonly messages: Memory;
@@ -64,10 +70,9 @@ export class ChatPrompt<TModelExtraParams extends {}> {
   }
 
   async chat(
-    inputArgs:
-      | string
-      | ContentPart[]
-      | { input: string | ContentPart[]; extraArgs?: TModelExtraParams },
+    inputArgs: CheckIfContainsNonOptional<TModelExtraParams> extends never
+      ? { input: string | ContentPart[]; extraArgs: TModelExtraParams }
+      : string | ContentPart[] | { input: string | ContentPart[]; extraArgs?: TModelExtraParams },
     onChunk?: (chunk: string) => void | Promise<void>
   ) {
     let input: string | ContentPart[] =

--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -7,8 +7,8 @@ import { Schema } from '../schema';
 import { Template } from '../template';
 import { StringTemplate } from '../templates';
 
-export type ChatPromptOptions<T extends {}> = T & {
-  readonly model: ChatModel<T>;
+export type ChatPromptOptions<TModelExtraParams extends {}> = TModelExtraParams & {
+  readonly model: ChatModel<TModelExtraParams>;
   readonly instructions?: string | Template;
   readonly role?: 'system' | 'user';
   readonly messages?: Message[] | Memory;

--- a/packages/openai/src/chat.ts
+++ b/packages/openai/src/chat.ts
@@ -80,7 +80,7 @@ export class OpenAIChatModel
     params: ChatParams<OpenAIChatModelOptions | AzureOpenAIChatModelOptions>,
     onChunk?: (chunk: ModelMessage) => void | Promise<void>
   ): Promise<ModelMessage> {
-    const { model, input, messages: paramsMessages, functions, ...extraParams } = params;
+    const { input, messages: paramsMessages, functions, ...extraParams } = params;
     const memory = paramsMessages || new LocalMemory();
     await memory.push(params.input);
 

--- a/packages/openai/src/chat.ts
+++ b/packages/openai/src/chat.ts
@@ -20,7 +20,7 @@ export interface OpenAIChatModelOptions {
   readonly requestOptions?:
     | OpenAI.ChatCompletionCreateParams
     | ((
-        params: ChatParams
+        params: ChatParams<OpenAIChatModelOptions | AzureOpenAIChatModelOptions>
       ) => OpenAI.ChatCompletionCreateParams | Promise<OpenAI.ChatCompletionCreateParams>);
 }
 
@@ -42,7 +42,9 @@ export interface AzureOpenAIChatModelOptions extends OpenAIChatModelOptions {
   azureADTokenProvider?: () => Promise<string>;
 }
 
-export class OpenAIChatModel implements ChatModel {
+export class OpenAIChatModel
+  implements ChatModel<OpenAIChatModelOptions | AzureOpenAIChatModelOptions>
+{
   private readonly _openai: OpenAI;
   private readonly _log: Logger;
 
@@ -75,17 +77,18 @@ export class OpenAIChatModel implements ChatModel {
   }
 
   async chat(
-    params: ChatParams,
+    params: ChatParams<OpenAIChatModelOptions | AzureOpenAIChatModelOptions>,
     onChunk?: (chunk: ModelMessage) => void | Promise<void>
   ): Promise<ModelMessage> {
-    const memory = params.messages || new LocalMemory();
+    const { model, input, messages: paramsMessages, functions, ...extraParams } = params;
+    const memory = paramsMessages || new LocalMemory();
     await memory.push(params.input);
 
     // call functions
-    if (params.input.role === 'model' && params.input.function_calls?.length) {
-      for (const call of params.input.function_calls) {
+    if (input.role === 'model' && input.function_calls?.length) {
+      for (const call of input.function_calls) {
         const log = this._log.child(`tools/${call.name}`);
-        const fn = (params.functions || {})[call.name];
+        const fn = (functions || {})[call.name];
 
         if (!fn) {
           throw new Error(`function ${call.name} not found`);
@@ -134,10 +137,11 @@ export class OpenAIChatModel implements ChatModel {
         temperature: this.options.temperature,
         stream: this.options.stream,
         ...requestOptions,
+        ...extraParams,
         tools:
-          Object.keys(params.functions || {}).length === 0
+          Object.keys(functions || {}).length === 0
             ? undefined
-            : Object.values(params.functions || {}).map((fn) => ({
+            : Object.values(functions || {}).map((fn) => ({
                 type: 'function',
                 function: {
                   name: fn.name,


### PR DESCRIPTION
Sometimes we want to send extra parameters to model requests. Right now it's not really possible and we're constrained to ChatParams. In this PR, I'm proposing adding extra parameters to ChatParams that the model can define and this can be optionally passed in.

I made this "partial" as to not break anything, but I'm not opposed to this being required. But this might lead to a breaking change.